### PR TITLE
Be able to pass contract addresses as envrionment variables

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,13 +8,26 @@ if [ "${LOCAL_CONTRACTS}" = "true" ]; then
     sleep 2
   done
 fi
-market=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/OceanMarket.development.json', 'r'))['address'])")
-token=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/OceanToken.development.json', 'r'))['address'])")
-auth=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/OceanAuth.development.json', 'r'))['address'])")
-did=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/DIDRegistry.development.json', 'r'))['address'])")
-sed -i -e "/token.address =/c token.address = ${token}" /brizo/config.ini
-sed -i -e "/market.address =/c market.address = ${market}" /brizo/config.ini
-sed -i -e "/auth.address =/c auth.address = ${auth}" /brizo/config.ini
-sed -i -e "/didregistry.address =/c didregistry.address = ${did}" /brizo/config.ini
+
+if [ -z "${MARKET_ADDRESS}" ]; then
+  market=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/OceanMarket.development.json', 'r'))['address'])")
+  sed -i -e "/market.address =/c market.address = ${market}" /brizo/config.ini
+fi
+
+if [ -z "${AUTH_ADDRESS}" ]; then
+  auth=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/OceanAuth.development.json', 'r'))['address'])")
+  sed -i -e "/auth.address =/c auth.address = ${auth}" /brizo/config.ini
+fi
+
+if [ -z "${TOKEN_ADDRESS}" ]; then
+  token=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/OceanToken.development.json', 'r'))['address'])")
+  sed -i -e "/token.address =/c token.address = ${token}" /brizo/config.ini
+fi
+
+if [ -z "${DIDREGISTRY_ADDRESS}" ]; then
+  did=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/DIDRegistry.development.json', 'r'))['address'])")
+  sed -i -e "/didregistry.address =/c didregistry.address = ${did}" /brizo/config.ini
+fi
+
 gunicorn -b ${BRIZO_URL#*://} -w ${BRIZO_WORKERS} brizo.run:app
 tail -f /dev/null


### PR DESCRIPTION
## Description

Currently the contract addresses are always get from a shared folder where the contracts must place.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()