### PR TITLE
upgraded requests version to  >=20

### DIFF
--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -168,7 +168,7 @@ python-rapidjson==0.6.3
 python-rapidjson-schema==0.1.1
 pytz==2018.5
 PyYAML==3.13
-requests==2.19.1
+requests>=2.20.0
 requests-oauthlib==1.0.0
 requests-toolbelt==0.8.0
 rethinkdb==2.3.0.post6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -172,7 +172,7 @@ python-rapidjson==0.6.3
 python-rapidjson-schema==0.1.1
 pytz==2018.5
 PyYAML==3.13
-requests==2.20.0
+requests>=2.20.0
 requests-oauthlib==1.0.0
 requests-toolbelt==0.8.0
 rethinkdb==2.3.0.post6


### PR DESCRIPTION
## Description

upgraded requests version to >= 20

Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

## Is this PR related with an open issue?

No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->](https://media.giphy.com/media/l4pTosVr0iHCJ11hm/giphy.gif)