### PR TITLE
Workaround for getting correct addresses in development

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -30,5 +30,7 @@ if [ -z "${DIDREGISTRY_ADDRESS}" ]; then
   sed -i -e "/didregistry.address =/c didregistry.address = ${did}" /brizo/config.ini
 fi
 
+/bin/cp -rp /usr/local/keeper-contracts/* /usr/local/artifacts/
+
 gunicorn -b ${BRIZO_URL#*://} -w ${BRIZO_WORKERS} brizo.run:app
 tail -f /dev/null


### PR DESCRIPTION
## Description

When deployed in a distributed environment (k8s as example), the `wait_for_migration_and_extract_keeper_artifacts.sh` does not provide a valid solution. This workaround should solve in that case.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()