### PR TITLE
stop Travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,6 @@ deploy:
     tags: true
     repo: oceanprotocol/brizo
     python: 3.6
+
+notifications:
+  email: false


### PR DESCRIPTION
Getting an email for every Travis build is a bit noisy so prevent that from happening. Feel free to close PR if getting build emails is actually intended.