### PR TITLE
Consolidate bumpversion config in .bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,8 @@
 [bumpversion]
 current_version = 0.1.3
-
-[bumpversion:file:setup.cfg]
+commit = True
+tag = True
 
 [bumpversion:file:setup.py]
-
+search = version='{current_version}'
+replace = version='{new_version}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ services:
 before_install:
   - git clone https://github.com/oceanprotocol/barge
   - cd barge
-  - bash -x start_ocean.sh --latest --no-brizo --no-pleuston --local-spree-node 2>&1 > start_ocean.log &
+  - KEEPER_VERSION=v0.5.1 bash -x start_ocean.sh --latest --no-brizo --no-pleuston --local-spree-node 2>&1 > start_ocean.log &
+  - sleep 15
 
-# Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis
 script: tox
 deploy:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.1.3
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:brizo/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 
@@ -18,11 +5,9 @@ universal = 1
 exclude = docs
 ignore = E501, E402, E126
 
-
 [aliases]
 # Define setup.py command aliases here
 test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-


### PR DESCRIPTION
The `bumpversion` script first checks for configuration settings in `.bumpversion.cfg` and then in `setup.cfg` so I just consolidated them all in `.bumpversion.cfg`. This is the same as how things are set up in squid-py, so it should work fine.

Note that I removed the `[bumpversion:file:brizo/__init__.py]` section because that file is empty, so there's no version number to bump in there.

Note that `run.py` also reads the `.bumpversion.cfg` file to determine the current version.