### PR TITLE
Removed AQUARIUS_URL variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ ENV AZURE_SUBSCRIPTION_ID=''
 ENV AZURE_SHARE_INPUT='compute'
 ENV AZURE_SHARE_OUTPUT='output'
 
-ENV AQUARIUS_URL='http://0.0.0.0:5000'
 ENV BRIZO_URL='http://0.0.0.0:8030'
 
 # docker-entrypoint.sh configuration file variables


### PR DESCRIPTION
## Description

Remove AQUARIUS_URL variable because it is not needed now.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()