### PR TITLE
Copy and keep new files

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "${LOCAL_CONTRACTS}" = "true" ]; then
   done
 fi
 
-/bin/cp -np /usr/local/keeper-contracts/* /usr/local/artifacts/ || true
+/bin/cp -up /usr/local/keeper-contracts/* /usr/local/artifacts/ || true
 
 gunicorn -b ${BRIZO_URL#*://} -w ${BRIZO_WORKERS} brizo.run:app
 tail -f /dev/null


### PR DESCRIPTION
## Description

Option `-n` is not available in `cp` of docker image. Replace by option `-u` (keep latest version of files when `cp`ing).

## Is this PR related with an open issue?

Related to Issue #55 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()