### PR TITLE
SLA → service agreement

### DIFF
--- a/brizo/routes.py
+++ b/brizo/routes.py
@@ -32,7 +32,7 @@ logger = logging.getLogger('brizo')
 
 @services.route('/access/initialize', methods=['POST'])
 def initialize():
-    """Initialize the SLA between the publisher and the consumer.
+    """Initialize the service agreement between the publisher and the consumer.
 
     ---
     tags:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ json_brizo = {
 
 
 @pytest.fixture
-def sla_template():
+def service_agreement_template():
     return
 
 


### PR DESCRIPTION
On Gitter, @danacr [noticed](https://gitter.im/oceanprotocol/Lobby?at=5c87cc4be527821f0a478b13) that we still used the "SLA" terminology in some Brizo code (which propagated through to the Brizo API docs at docs.oceanprotocol.com).

This pull request changes the two instances of "SLA" to "service agreement", which is the terminology used in the rest of the Brizo code.

Note: The pytest fixture named `sla_template` doesn't do anything and isn't being used anywhere but I kept it around (renamed) in case it's in the testing code for some reason (e.g. anticipation of future use).