### PR TITLE
add headers for big files in browser download

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3
+current_version = 0.3.4
 commit = True
 tag = True
 

--- a/brizo/routes.py
+++ b/brizo/routes.py
@@ -321,8 +321,9 @@ def consume():
                         headers = {"Range": request.headers.get('range')}
                         response = requests_session.get(download_url, headers=headers, stream=True)
                     else:
-                        headers = {f'"Content-Disposition":"attachment;'
-                                   f'filename={download_url.split("/")[-1]}"'}
+                        headers = {"Content-Disposition": "attachment",
+                                   "filename": download_url.split("/")[-1]
+                                   }
                         response = requests_session.get(download_url, headers=headers, stream=True)
                     file = io.BytesIO(response.content)
                     return file.read(), response.status_code

--- a/brizo/routes.py
+++ b/brizo/routes.py
@@ -321,8 +321,8 @@ def consume():
                         headers = {"Range": request.headers.get('range')}
                         response = requests_session.get(download_url, headers=headers, stream=True)
                     else:
-                        headers = {"Content-Disposition": "attachment",
-                                   "filename": download_url.split("/")[-1]
+                        headers = {"Content-Disposition":
+                                       f'attachment;filename={download_url.split("/")[-1]}'
                                    }
                         response = requests_session.get(download_url, headers=headers, stream=True)
                     file = io.BytesIO(response.content)

--- a/brizo/routes.py
+++ b/brizo/routes.py
@@ -325,8 +325,7 @@ def consume():
                                        f'attachment;filename={url.split("/")[-1]}'
                                    }
                         response = requests_session.get(download_url, headers=headers, stream=True)
-                    file = io.BytesIO(response.content)
-                    return Response(file.read(), response.status_code, headers=headers)
+                    return Response(io.BytesIO(response.content).read(), response.status_code, headers=headers)
                 except Exception as e:
                     logger.error(e)
                     return "Error getting the url content: %s" % e, 401

--- a/brizo/routes.py
+++ b/brizo/routes.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 from eth_utils import add_0x_prefix
-from flask import Blueprint, request
+from flask import Blueprint, request, Response
 from osmosis_driver_interface.osmosis import Osmosis
 from squid_py import ConfigProvider
 from squid_py.config import Config
@@ -322,12 +322,11 @@ def consume():
                         response = requests_session.get(download_url, headers=headers, stream=True)
                     else:
                         headers = {"Content-Disposition":
-                                       f'attachment;filename={download_url.split("/")[-1]}'
+                                       f'attachment;filename={url.split("/")[-1]}'
                                    }
                         response = requests_session.get(download_url, headers=headers, stream=True)
-                        response.headers['ContentDisposition'] = f'attachment;filename={download_url.split("/")[-1]}'
                     file = io.BytesIO(response.content)
-                    return file.read(), response.status_code
+                    return Response(file.read(), response.status_code, headers=headers)
                 except Exception as e:
                     logger.error(e)
                     return "Error getting the url content: %s" % e, 401

--- a/brizo/routes.py
+++ b/brizo/routes.py
@@ -325,6 +325,7 @@ def consume():
                                        f'attachment;filename={download_url.split("/")[-1]}'
                                    }
                         response = requests_session.get(download_url, headers=headers, stream=True)
+                        response.headers['ContentDisposition'] = f'attachment;filename={download_url.split("/")[-1]}'
                     file = io.BytesIO(response.content)
                     return file.read(), response.status_code
                 except Exception as e:

--- a/brizo/routes.py
+++ b/brizo/routes.py
@@ -321,7 +321,9 @@ def consume():
                         headers = {"Range": request.headers.get('range')}
                         response = requests_session.get(download_url, headers=headers, stream=True)
                     else:
-                        response = requests_session.get(download_url, stream=True)
+                        headers = {f'"Content-Disposition":"attachment;'
+                                   f'filename={download_url.split("/")[-1]}"'}
+                        response = requests_session.get(download_url, headers=headers, stream=True)
                     file = io.BytesIO(response.content)
                     return file.read(), response.status_code
                 except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/oceanprotocol/brizo',
-    version='0.3.3',
+    version='0.3.4',
     zip_safe=False,
 )


### PR DESCRIPTION
## Description
Add the header to allow the download of big files in the browser.
## Is this PR related with an open issue?
#https://github.com/oceanprotocol/squid-py/issues/337

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->](https://media.giphy.com/media/l0K4hqqqwgFijgVLa/giphy.gif)