### PR TITLE
grab keeper version from different contract

### DIFF
--- a/brizo/run.py
+++ b/brizo/run.py
@@ -47,7 +47,7 @@ def version():
     info['contracts']['SignCondition'] = keeper.sign_condition.address
     info['contracts']['OceanToken'] = keeper.token.address
     info['contracts']['TemplateStoreManager'] = keeper.template_manager.address
-    info['keeper-version'] = keeper.token.version
+    info['keeper-version'] = keeper.did_registry.version
     info['provider-address'] = get_provider_account().address
     return jsonify(info)
 


### PR DESCRIPTION
Grabs the contract not from the `OceanToken` contract, because that one is not always updated.

Fixes squid-js contract mismatch detection in v2 commons.