### PR TITLE
compute response spec tweaks

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,8 +1,43 @@
 # Brizo Endpoints Specification
 
-This document specifies the endpoints for Brizo to be implemented by the core developers. The final implementation and its documentation happens in Swagger inline code comments and the latest implemented API documentation can be accessed via:
+This document specifies the endpoints for Brizo to be implemented by the core 
+developers. The final implementation and its documentation happens in Swagger 
+inline code comments and the latest implemented API documentation can be 
+accessed via:
 
 - [Docs: Brizo API Reference](https://docs.oceanprotocol.com/references/brizo/)
+
+## Compute endpoints
+All compute endpoints respond with an Array of status objects, each object 
+describing a compute job info. 
+
+Each status object will contain:
+```
+    owner:The owner of this compute job
+    agreementId:
+    jobId:
+    dateCreated:Unix timestamp of job creation
+    dateFinished:Unix timestamp when job finished
+    status:  Int, see below for list
+    statusText: String, see below
+    algorithmLogUrl: URL to get the algo log (for user)
+    resultsUrls: Array of URLs for algo outputs
+    resultsDid: If published, the DID
+```
+
+Status description (`statusText`): (see Operator-Service for full status list)
+
+| status   | Description               |
+|----------|---------------------------|
+|  1       | Job started               |
+|  2       | Configuring volumes       |
+|  3       | Running algorithm         |
+|  4       | Filtering results         |
+|  5       | Publishing results        |
+|  6       | Job completed             |
+|  7       | Job stopped               |
+|  8       | Job deleted successfully  |
+
 
 ## Create new job or restart an existing stopped job
 
@@ -21,7 +56,7 @@ Parameters
 ```
 
 Returns:
-`status` object
+Array of `status` objects as described above, in this case the array will have only one object
 
 
 Example:
@@ -29,15 +64,17 @@ Example:
 POST /api/v1/compute?signature=0x00110011&serviceAgreementId=0x1111&algorithmDid=0xa203e320008999099000
 ```
 
-Output:
+Response:
 
 ```json
-{
-  "jobId": "0x1111:001",
-  "status": 1,
-  "statusText": "Job started",
-  ...
-}
+[
+    {
+      "jobId": "0x1111:001",
+      "status": 1,
+      "statusText": "Job started",
+      ...
+    }
+]
 ```
 
 
@@ -61,34 +98,7 @@ Parameters
 
 Returns
 
-An Array of objects, each object describing a workflow. If the array is empty, then the search yields no results
-
-Each object will contain:
-```
-    owner:The owner of this compute job
-    agreementId:
-    jobId:
-    dateCreated:Unix timestamp of job creation
-    dateFinished:Unix timestamp when job finished
-    status:  Int, see below for list
-    statusText: String, see below
-    algologUrl: URL to get the algo log (for user)
-    outputsUrl: Array of URLs for algo outputs
-    resultsDid: If published, the DID
-```
-
-Status description: (see Operator-Service for full status list)
-
-| status   | Description               |
-|----------|---------------------------|
-|  1       | Job started               |
-|  2       | Configuring volumes       |
-|  3       | Running algorithm         |
-|  4       | Filtering results         |
-|  5       | Publishing results        |
-|  6       | Job completed             |
-|  7       | Job stopped               |
-|  8       | Job deleted successfully  |
+Array of `status` objects as described above
 
 
 Example:
@@ -96,8 +106,9 @@ Example:
 GET /api/v1/brizo/services/compute?signature=0x00110011&serviceAgreementId=0x1111&jobId=012023
 ```
 
-Output:
-```
+Response:
+
+```json
 [
       {
         "owner":"0x1111",
@@ -107,8 +118,8 @@ Output:
         "dateFinished":"2020-10-01T01:00:00Z",
         "status":5,
         "statusText":"Job finished",
-        "algologUrl":"http://example.net/logs/algo.log",
-        "outputsUrl":[
+        "algorithmLogUrl":"http://example.net/logs/algo.log",
+        "resultsUrls":[
             "http://example.net/logs/output/0",
             "http://example.net/logs/output/1"
          ],
@@ -122,8 +133,8 @@ Output:
         "dateFinished":"2020-10-01T01:00:00Z",
         "status":5,
         "statusText":"Job finished",
-        "algologUrl":"http://example.net/logs2/algo.log",
-        "outputsUrl":[
+        "algorithmLogUrl":"http://example.net/logs2/algo.log",
+        "resultsUrls":[
             "http://example.net/logs2/output/0",
             "http://example.net/logs2/output/1"
          ],
@@ -151,22 +162,24 @@ Parameters
 
 Returns
 
-Status, whether or not the job was stopped successfully.
+Array of `status` objects as described above
 
 Example:
 ```
 PUT /api/v1/brizo/services/compute?signature=0x00110011&serviceAgreementId=0x1111&jobId=012023
 ```
 
-Output:
+Response:
 
 ```json
-{
-  ...,
-  "status": 7,
-  "statusText": "Job stopped",
-  ...
-}
+[
+    {
+      ...,
+      "status": 7,
+      "statusText": "Job stopped",
+      ...
+    }
+]
 ```
 
 ## Delete
@@ -188,19 +201,21 @@ Parameters
 
 Returns
 
-Status, whether or not the job was removed successfully.
+Array of `status` objects as described above
 
 Example:
 ```
 DELETE /api/v1/brizo/services/compute?signature=0x00110011&serviceAgreementId=0x1111&jobId=012023
 ```
 
-Output:
+Response:
 ```json
-{
-  ...,
-  "status": 8,
-  "statusText": "Job deleted successfully",
-  ...
-}
+[
+    {
+      ...,
+      "status": 8,
+      "statusText": "Job deleted successfully",
+      ...
+    }
+]
 ```

--- a/API.md
+++ b/API.md
@@ -1,4 +1,8 @@
-# Brizo Endpoints
+# Brizo Endpoints Specification
+
+This document specifies the endpoints for Brizo to be implemented by the core developers. The final implementation and its documentation happens in Swagger inline code comments and the latest implemented API documentation can be accessed via:
+
+- [Docs: Brizo API Reference](https://docs.oceanprotocol.com/references/brizo/)
 
 ## Create new job or restart an existing stopped job
 

--- a/API.md
+++ b/API.md
@@ -4,7 +4,6 @@
 
 ### POST /api/v1/compute
 
-
 Start a new job
 
 Parameters
@@ -18,7 +17,7 @@ Parameters
 ```
 
 Returns:
-A string containing jobId
+`status` object
 
 
 Example:
@@ -27,13 +26,18 @@ POST /api/v1/compute?signature=0x00110011&serviceAgreementId=0x1111&algorithmDID
 ```
 
 Output:
-```
-jobId: "0x1111:001"
+
+```json
+{
+  "jobId": "0x1111:001",
+  "status": 1,
+  "statusText": "Job started",
+  ...
+}
 ```
 
 
 ## Status and Result
-  
   
 ### GET /api/v1/compute
    
@@ -69,14 +73,16 @@ Each object will contain:
 
 Status description:
 
-| status   | Description        |
-|----------|--------------------|
-|  1       | Job started        |
-|  2       | Configuring volumes|
-|  3       | Running algorith   |
-|  4       | Filtering results  |
-|  5       | Publishing results |
-|  6       | Job completed      |
+| status   | Description               |
+|----------|---------------------------|
+|  1       | Job started               |
+|  2       | Configuring volumes       |
+|  3       | Running algorith          |
+|  4       | Filtering results         |
+|  5       | Publishing results        |
+|  6       | Job completed             |
+|  7       | Job stopped               |
+|  8       | Job deleted successfully  |
 
 
 Example:
@@ -152,8 +158,14 @@ PUT /api/v1/compute?signature=0x00110011&serviceAgreementId=0x1111&jobId=012023
 ```
 
 Output:
-```
-OK
+
+```json
+{
+  ...,
+  "status": 7,
+  "statusText": "Job stopped",
+  ...
+}
 ```
 
 ## Delete
@@ -167,7 +179,6 @@ Parameters
     signature: String object containg user signature (signed message)
     serviceAgreementId: String object containing agreementID (optional)
     jobId: String object containing workflowID (optional)
-        
 ```
 
 Returns
@@ -180,6 +191,11 @@ DELETE /api/v1/compute?signature=0x00110011&serviceAgreementId=0x1111&jobId=0120
 ```
 
 Output:
-```
-OK
+```json
+{
+  ...,
+  "status": 8,
+  "statusText": "Job deleted successfully",
+  ...
+}
 ```

--- a/brizo/routes.py
+++ b/brizo/routes.py
@@ -285,7 +285,7 @@ def compute_delete_job():
     ]
     msg, status = check_required_attributes(required_attributes, data, 'compute')
     if msg:
-        return msg, status
+        return jsonify(error=msg), status
 
     try:
         agreement_id = data.get('serviceAgreementId')
@@ -308,16 +308,20 @@ def compute_delete_job():
             get_compute_endpoint(),
             params=body,
             headers={'content-type': 'application/json'})
-        return response.content
+        return Response(
+            response.content,
+            response.status_code,
+            headers={'content-type': 'application/json'}
+        )
 
     except InvalidSignatureError as e:
         msg = f'Consumer signature failed verification: {e}'
         logger.error(msg, exc_info=1)
-        return msg, 401
+        return jsonify(error=msg), 401
 
     except (ValueError, Exception) as e:
         logger.error(f'Error- {str(e)}', exc_info=1)
-        return f'Error : {str(e)}', 500
+        return jsonify(error=f'Error : {str(e)}'), 500
 
 
 @services.route('/compute', methods=['PUT'])
@@ -365,7 +369,7 @@ def compute_stop_job():
     ]
     msg, status = check_required_attributes(required_attributes, data, 'compute')
     if msg:
-        return msg, status
+        return jsonify(error=msg), status
 
     try:
         agreement_id = data.get('serviceAgreementId')
@@ -388,16 +392,20 @@ def compute_stop_job():
             get_compute_endpoint(),
             params=body,
             headers={'content-type': 'application/json'})
-        return response.content
+        return Response(
+            response.content,
+            response.status_code,
+            headers={'content-type': 'application/json'}
+        )
 
     except InvalidSignatureError as e:
         msg = f'Consumer signature failed verification: {e}'
         logger.error(msg, exc_info=1)
-        return msg, 401
+        return jsonify(error=msg), 401
 
     except (ValueError, Exception) as e:
         logger.error(f'Error- {str(e)}', exc_info=1)
-        return f'Error : {str(e)}', 500
+        return jsonify(error=f'Error : {str(e)}'), 500
 
 
 @services.route('/compute', methods=['GET'])
@@ -445,7 +453,7 @@ def compute_get_status_job():
     ]
     msg, status = check_required_attributes(required_attributes, data, 'compute')
     if msg:
-        return msg, status
+        return jsonify(error=msg), status
 
     try:
         agreement_id = data.get('serviceAgreementId')
@@ -468,16 +476,20 @@ def compute_get_status_job():
             get_compute_endpoint(),
             params=body,
             headers={'content-type': 'application/json'})
-        return response.content
+        return Response(
+            response.content,
+            response.status_code,
+            headers={'content-type': 'application/json'}
+        )
 
     except InvalidSignatureError as e:
         msg = f'Consumer signature failed verification: {e}'
         logger.error(msg, exc_info=1)
-        return msg, 401
+        return jsonify(error=msg), 401
 
     except (ValueError, Exception) as e:
         logger.error(f'Error- {str(e)}', exc_info=1)
-        return f'Error : {str(e)}', 500
+        return jsonify(error=f'Error : {str(e)}'), 500
 
 
 @services.route('/compute', methods=['POST'])
@@ -532,7 +544,7 @@ def compute_start_job():
     ]
     msg, status = check_required_attributes(required_attributes, data, 'compute')
     if msg:
-        return msg, status
+        return jsonify(error=msg), status
 
     agreement_id = data.get('serviceAgreementId')
     consumer_address = data.get('consumerAddress')
@@ -608,8 +620,8 @@ def compute_start_job():
     except InvalidSignatureError as e:
         msg = f'Consumer signature failed verification: {e}'
         logger.error(msg, exc_info=1)
-        return msg, 401
+        return jsonify(error=msg), 401
 
     except (ValueError, KeyError, Exception) as e:
         logger.error(f'Error- {str(e)}', exc_info=1)
-        return f'Error : {str(e)}', 500
+        return jsonify(error=f'Error : {str(e)}'), 500

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -286,7 +286,7 @@ def get_compute_job_info(client, endpoint, params):
         data=json.dumps(params),
         content_type='application/json'
     )
-    assert response.status == '200 OK' and response.data, \
+    assert response.status_code == 200 and response.data, \
         f'get compute job info failed: status {response.status}, data {response.data}'
 
     job_info = response.json if response.json else json.loads(response.data)


### PR DESCRIPTION
Unify all `/compute` responses. They're basically all a `status` object. `GET` continues to return an array of those objects