### PR TITLE
Part of DLP PR

### DIFF
--- a/brizo/routes.py
+++ b/brizo/routes.py
@@ -688,10 +688,22 @@ def compute_start_job():
         if not asset_urls:
             return jsonify(error=f'cannot get url(s) in input did {did}.'), 400
 
+        categories = []
+
+        # ! will gather categories and unify them across ALL DIDS
+        try:
+          for category in asset.as_dictionary()["service"]:
+            attrs = category["attributes"]
+            extra = attrs["additionalInformation"]
+            categories.extend(extra["categories"])
+        except Exception:
+          pass
+
         input_dict = dict({
             'index': 0,
             'id': did,
-            'url': asset_urls
+            'url': asset_urls,
+            'data_categories': categories,
         })
 
         #########################


### PR DESCRIPTION
Adds data categories that we pass to workflow so that when we create the filter job we can pass those down to the pod so that it knows which keywords to use in one of its conditions (recall that we have keywords per environment per data categor[y][ies].